### PR TITLE
URL as cli argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,88 @@
+# Created by .ignore support plugin (hsz.mobi)
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+

--- a/cmd/tlsextract/main.go
+++ b/cmd/tlsextract/main.go
@@ -37,8 +37,6 @@ func main() {
 		}
 	}
 
-	fmt.Printf("url: %#v\n", parsedURL)
-
 	if parsedURL.Port() == "" {
 		parsedURL.Host += ":443"
 	}


### PR DESCRIPTION
Added the ability to pass an entire URL or the simple `host:port` argument.
Now it is possible to call `tlsextract` in the following ways:
```
tlsextract https://withuser@example.com:443/some/path/on/some/domain?with=query&args=even
tlsextract https://example.com
tlsextract example.com
...
```

Also added a `.gitignore` and a utlity `checkErr(err error)` function.